### PR TITLE
BUILD-8073 Migrate public repositories workflows to large runners

### DIFF
--- a/.github/workflows/its.yml
+++ b/.github/workflows/its.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       contents: read
       checks: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   pre-commit:
     name: "pre-commit"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     steps:
       - uses: SonarSource/gh-action_pre-commit@fc9d73025994fd1c2b96d568c8c8a4af82a3ae21 # 1.0.6
         with:


### PR DESCRIPTION
Migrates public repository workflows from standard GitHub-hosted runners to **Large Runners**
(`ubuntu-latest` → `ubuntu-latest-large`, etc.).

See [BUILD-8073](https://sonarsource.atlassian.net/browse/BUILD-8073) for details.


[BUILD-8073]: https://sonarsource.atlassian.net/browse/BUILD-8073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ