### PR TITLE
BUILD-10835 Migrate GitHub-hosted Ubuntu runners to warp-custom-ubuntu-24-04

### DIFF
--- a/.github/workflows/its.yml
+++ b/.github/workflows/its.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   build:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       contents: read
       checks: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   pre-commit:
     name: "pre-commit"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: SonarSource/gh-action_pre-commit@fc9d73025994fd1c2b96d568c8c8a4af82a3ae21 # 1.0.6
         with:


### PR DESCRIPTION
BUILD-10835 This change moves CI from GitHub-hosted Ubuntu runner labels to the shared WarpBuild image `warp-custom-ubuntu-24-04`, in line with the platform runner migration.

## Summary

- Replaces `github-ubuntu-latest-*` with `warp-custom-ubuntu-24-04` in the workflows listed in the migration scan.

## Files

- `.github/workflows/its.yml`
- `.github/workflows/main.yml`
- `.github/workflows/pre-commit.yml`

## Notes for reviewers

- No intentional changes to job logic, permissions, or steps beyond `runs-on` / default runner strings.
- Please confirm workflows still match org expectations for this repository after merge.
