### PR TITLE
BUILD-10781 Bump JS deps toward Node 24 runtimes

### DIFF
--- a/.github/workflows/its.yml
+++ b/.github/workflows/its.yml
@@ -10,11 +10,11 @@ jobs:
       checks: read
       id-token: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Get Last Check Suite
         id: check_suite
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: github-ubuntu-latest-s
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install poetry
         run: pipx install poetry
 
       - name: Set up Python
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version-file: pyproject.toml
           cache: 'poetry'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,7 +8,7 @@ jobs:
     name: "pre-commit"
     runs-on: github-ubuntu-latest-s
     steps:
-      - uses: SonarSource/gh-action_pre-commit@fc9d73025994fd1c2b96d568c8c8a4af82a3ae21 # 1.0.6
+      - uses: SonarSource/gh-action_pre-commit@2ddc0c7fdabce0adfaaa4075a17690972ed9961a # 1.2.0
         with:
           extra-args: >
             --from-ref=origin/${{ github.event.pull_request.base.ref }}

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: Slack Secrets
       if: ${{ !env.ACT }}
       id: secrets
-      uses: SonarSource/vault-action-wrapper@d6d745ffdbc82b040df839b903bc33b5592cd6b0 # 3.0.2
+      uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
       with:
         secrets: |
           development/kv/data/slack token | slack_token;
@@ -23,13 +23,13 @@ runs:
       shell: bash
 
     - name: Set up Python
-      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version-file: ${{ github.action_path }}/pyproject.toml
         # Remove cache: 'poetry'
 
     - name: Cache Poetry dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       id: poetry-cache
       with:
         path: ${{ github.action_path }}/.venv

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: Slack Secrets
       if: ${{ !env.ACT }}
       id: secrets
-      uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+      uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
       with:
         secrets: |
           development/kv/data/slack token | slack_token;


### PR DESCRIPTION
## Why

GitHub deprecates Node 20 on Actions runners starting **2026-06-02**. This action carried the worst legacy state in the cascade:

- `actions/cache@v3` — already EOL by GitHub itself (Node 16/20).
- `actions/setup-python@v5.4.0` — Node 20.
- `SonarSource/vault-action-wrapper@3.0.2` — stale (current latest is 3.4.0).

Linked ticket: [BUILD-10781](https://sonarsource.atlassian.net/browse/BUILD-10781).

## What changed

- `actions/cache` v3 → **v5.0.5** (Node 24; also pin by SHA per repo convention).
- `actions/setup-python` v5.4.0 → **v6.2.0** (Node 24).
- `SonarSource/vault-action-wrapper` 3.0.2 → **3.4.0** (refresh stale pin). 3.4.0 itself is still on Node 20 internally; a follow-up bump is needed once vault-action-wrapper ships its Node 24 release ([tracking PR](https://github.com/SonarSource/vault-action-wrapper/pull/75)).

## Verification

- `pre-commit` clean on touched files.
- CI on this PR exercises the action via `Run main.py`.


[BUILD-10781]: https://sonarsource.atlassian.net/browse/BUILD-10781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

----
## Summary by Gitar

- **Dependency upgrades:**
  - Bumped `SonarSource/vault-action-wrapper` to `3.5.0` in `action.yml`.
  - Upgraded `actions/checkout` to `v6.0.2` and `actions/github-script` to `v9.0.0` in CI workflows.
  - Bumped `SonarSource/gh-action_pre-commit` to `1.2.0` in `pre-commit.yml`.

<sub>This will update automatically on new commits.</sub>